### PR TITLE
RHEL 8 support - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following distributions are supported on the x86_64 architecture:
 - Oracle Linux 7
 - Oracle Linux 8
 - Red Hat Enterprise Linux 7
+- Red Hat Enterprise Linux 8
 - Rocky Linux 8
 - Scientific Linux 7
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The following distributions are supported on the x86_64 architecture:
 - Rocky Linux 8
 - Scientific Linux 7
 
+The distributions must be up to date and only their latest minor release is
+supported.
+
 ## Preparations
 
 The script covers the basics of several Enterprise Linux installations but it


### PR DESCRIPTION
Mentioned that RHEL 8 migration is now supported and that only the latest minor releases of the supported distros are supported (e.g. no 7.0 -> 7.9 migration support as of today).