### PR TITLE
Hotfix for CentOS 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,17 @@ bash -x migrate2eurolinux.sh -f -u 'user@example.com' -p 'password123' | tee -a 
 ### Removing distro-provided kernel
 
 Once the script has finished, there will still be a distro-provided kernel
-running and probably some other ones, especially when installed from
-third-party repositories. In order to remove it and related packages such as
-*kernel-devel*, *kernel-headers*, etc. an additional script has been created:
-*remove_kernels.sh*.
+running and maybe some other ones if you ran the script with the `-b` option -
+especially those installed from third-party repositories. In order to remove
+it and related packages such as *kernel-devel*, *kernel-headers*, etc. an
+additional script has been created: *remove_kernels.sh*.
 
 The script will run only if it is certain a system has already successfully
-migrated to EuroLinux. Additionally, it will ask the user, if they want to
-remove only the kernels their old distro provided or all non-EuroLinux kernels
-and related packages - those from third-party repositories among others.
+migrated to EuroLinux. The default behavior is to remove everything that is
+not provided by EuroLinux but the user can specify, if they want to remove
+only the kernels their old distro provided or all non-EuroLinux kernels and
+related packages - those from third-party repositories among others. Or if
+they want to perform a dry-run for listing, what would happen.
 
 Once the answer is present, a systemd service will be created and enabled - it
 will remove the specified packages on next system boot, perform a bootloader

--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ especially those installed from third-party repositories. In order to remove
 it and related packages such as *kernel-devel*, *kernel-headers*, etc. an
 additional script has been created: *remove_kernels.sh*.
 
-The script will run only if it is certain a system has already successfully
-migrated to EuroLinux. The default behavior is to remove everything that is
-not provided by EuroLinux but the user can specify, if they want to remove
-only the kernels their old distro provided or all non-EuroLinux kernels and
-related packages - those from third-party repositories among others. Or if
-they want to perform a dry-run for listing, what would happen.
+Once the migration has been completed, you are recommended to reboot your
+system and only then the *remove_kernels.sh* script shall be launched.
+
+The script will proceed  only if it is certain a system has already
+successfully migrated to EuroLinux. The default behavior is to remove
+everything that is not provided by EuroLinux but the user can specify, if they
+want to remove only the kernels their old distro provided or all non-EuroLinux
+kernels and related packages - those from third-party repositories among
+others. Or if they want to perform a dry-run for listing, what would happen.
 
 Once the answer is present, a systemd service will be created and enabled - it
 will remove the specified packages on next system boot, perform a bootloader

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ bash migrate2eurolinux.sh
 
 You can specify several parameters:
 
+- `-b` to preserve several non-EuroLinux components such as packages from
+  unofficial repositories, disabled and backed-up .repo files from your
+  current distribution, etc. rather than cleaning them up.
 - `-f` to skip a warning message about backup recommendation. Necessary for
   running non-interactively.
 - `-u` to specify your EuroMan username

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -670,24 +670,12 @@ reinstall_all_rpms() {
 }
 
 update_grub() {
-  # Cover all distros and versions bootloader entries.
-  # TODO: more EFI entries?
-  case "$os_version" in
-    7* | 8*)
-      echo "Updating the GRUB2 bootloader..."
-      if [ -d /sys/firmware/efi ]; then
-        if [ -d /boot/efi/EFI/almalinux ]; then
-          grub2-mkconfig -o /boot/efi/EFI/almalinux/grub.cfg
-        elif [ -d /boot/efi/EFI/centos ]; then
-          grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg
-        else
-          grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
-        fi
-      else
-        grub2-mkconfig -o /boot/grub2/grub.cfg
-      fi
-    ;;
-  esac
+  # Update bootloader entries. Output to a symlink which always points to the
+  # proper configuration file.
+  printf "Updating the GRUB2 bootloader at: "
+  [ -d /sys/firmware/efi ] && grub2_conf="/etc/grub2-efi.cfg" || grub2_conf="/etc/grub2.cfg"
+  printf "$grub2_conf (symlinked to $(readlink $grub2_conf)).\n"
+  grub2-mkconfig -o "$grub2_conf"
 }
 
 remove_leftovers() {

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -669,12 +669,17 @@ reinstall_all_rpms() {
   # two lines rather than one due to their long filename - the output is
   # modified via `sed` to deal with this curiosity.
    mapfile -t non_eurolinux_rpms_from_yum_list < <(yum list installed | sed '/^[^@]*$/{N;s/\n//}' | grep -Ev '@el-server-|@euroman|@fbi|@certify' | grep '@' | cut -d' ' -f 1 | cut -d'.' -f 1)
-   mapfile -t non_eurolinux_rpms < <(rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}|%{VENDOR}|%{PACKAGER}\n" ${non_eurolinux_rpms_from_yum_list[*]} | grep -Ev 'EuroLinux|Scientific') 
+   mapfile -t non_eurolinux_rpms < <(rpm -qa --qf "%{NEVRA}|%{VENDOR}|%{PACKAGER}\n" ${non_eurolinux_rpms_from_yum_list[*]} | grep -Ev 'EuroLinux|Scientific') 
   if [[ -n "${non_eurolinux_rpms[*]}" ]]; then
     echo "The following non-EuroLinux RPMs are installed on the system:"
     printf '\t%s\n' "${non_eurolinux_rpms[@]}"
     echo "This may be expected of your environment and does not necessarily indicate a problem."
     echo "If a large number of RPMs from other vendors are included and you're unsure why please open an issue on ${github_url}"
+    if [ "$preserve" != "true" ]; then
+      echo "Removing these packages automatically..."
+      yum remove-nevra -y "${non_eurolinux_rpms[@]%%|*}"
+    fi
+
   fi
 }
 

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -677,8 +677,12 @@ reinstall_all_rpms() {
     echo "If a large number of RPMs from other vendors are included and you're unsure why please open an issue on ${github_url}"
     if [ "$preserve" != "true" ]; then
       echo "Removing these packages (except those kernel-related) automatically..."
-      non_eurolinux_rpms=( ${non_eurolinux_rpms_and_metadata[@]%%|*} )
-      yum remove-nevra -y ${non_eurolinux_rpms[@]/kernel*/}
+      non_eurolinux_rpms_and_metadata_without_kernel_related=( ${non_eurolinux_rpms_and_metadata[@]/kernel*/} )
+      if [ ${#non_eurolinux_rpms_and_metadata_without_kernel_related[@]} -gt 0 ]; then
+        yum remove-nevra -y ${non_eurolinux_rpms_and_metadata_without_kernel_related[@]%%|*}
+      else
+        echo "(no need to remove anything)"
+      fi
     fi
   fi
 }

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -381,7 +381,6 @@ register_to_euroman() {
       fi
       echo "Installing EuroMan-related tools..."
       yum install -y python-hwdata rhn-client-tools rhn-check yum-rhn-plugin yum-utils rhnlib rhn-setup rhnsd
-      yum update -y  python-hwdata rhn-client-tools rhn-check yum-rhn-plugin yum-utils rhnlib rhn-setup rhnsd
       echo "Determining el_org_id based on your registration name & password..."
       el_org_id=$(python2 -c "
 import xmlrpclib

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -648,7 +648,12 @@ reinstall_all_rpms() {
   # party repositories such as EPEL.
   echo "Reinstalling all RPMs..."
   yum reinstall -y \*
-  mapfile -t non_eurolinux_rpms < <(rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}|%{VENDOR}|%{PACKAGER}\n" |grep -Ev 'EuroLinux|Scientific') # Several packages are branded as from Scientific Linux and that's the expected behavior
+
+  # Query all packages and their metadata such as their Vendor. The result of
+  # the query will be stored in a Bash array named non_eurolinux_rpms.
+  # Since earlier EuroLinux packages are branded as Scientific Linux, an
+  # additional pattern is considered when looking up EuroLinux products.
+   mapfile -t non_eurolinux_rpms < <(rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}|%{VENDOR}|%{PACKAGER}\n" |grep -Ev 'EuroLinux|Scientific') 
   if [[ -n "${non_eurolinux_rpms[*]}" ]]; then
     echo "The following non-EuroLinux RPMs are installed on the system:"
     printf '\t%s\n' "${non_eurolinux_rpms[@]}"

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -293,12 +293,7 @@ grab_gpg_keys() {
   # Get EuroLinux public GPG keys; store them in a predefined location before
   # adding any repositories.
   echo "Grabbing EuroLinux GPG keys..."
-  case "$os_version" in
-    7* | 8*)
-      curl "https://fbi.cdn.euro-linux.com/security/RPM-GPG-KEY-eurolinux$major_os_version" > "/etc/pki/rpm-gpg/RPM-GPG-KEY-eurolinux$major_os_version"
-      ;;
-    *) exit_message "You appear to be running an unsupported OS version: ${os_version}." ;;
-  esac
+  curl "https://fbi.cdn.euro-linux.com/security/RPM-GPG-KEY-eurolinux$major_os_version" > "/etc/pki/rpm-gpg/RPM-GPG-KEY-eurolinux$major_os_version"
 }
 
 create_temp_el_repo() {

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -753,7 +753,7 @@ main() {
 
 while getopts "bfhp:u:" option; do
     case "$option" in
-        b) preserve="true"
+        b) preserve="true" ;;
         f) skip_warning="true" ;;
         h) usage ;;
         p) el_euroman_password="$OPTARG" ;;

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -506,7 +506,7 @@ remove_centos_yum_branding() {
   # removals will be provided here.
   if [[ "$old_release" =~ centos ]]; then
     echo "Removing CentOS-specific yum configuration from /etc/yum.conf..."
-    sed -i.bak -e 's/^distroverpkg/#&/g' -e 's/^bugtracker_url/#&/g' /etc/yum.conf
+    sed -i.bak -e 's/^distroverpkg.*//g' -e 's/^bugtracker_url.*//g' /etc/yum.conf
   fi
 }
 

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -145,13 +145,7 @@ prepare_pre_migration_environment() {
   # approaches and tweaks. Store these details for later use.
   os_version=$(rpm -q "${old_release}" --qf "%{version}")
   major_os_version=${os_version:0:1}
-  base_packages=(basesystem initscripts el-logos el-release)
-  case "$os_version" in
-    7* | 8*)
-      base_packages=("${base_packages[@]}" plymouth grub2 grubby)
-      ;;
-    *) exit_message "You appear to be running an unsupported OS version: ${os_version}." ;;
-  esac
+  base_packages=(basesystem el-logos el-release grub2 grubby initscripts plymouth)
   if [[ "$old_release" =~ oraclelinux-release-(el)?[78] ]] ; then
     echo "Oracle Linux detected - unprotecting systemd temporarily for distro-sync to succeed..."
     mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -669,17 +669,17 @@ reinstall_all_rpms() {
   # two lines rather than one due to their long filename - the output is
   # modified via `sed` to deal with this curiosity.
    mapfile -t non_eurolinux_rpms_from_yum_list < <(yum list installed | sed '/^[^@]*$/{N;s/\n//}' | grep -Ev '@el-server-|@euroman|@fbi|@certify' | grep '@' | cut -d' ' -f 1 | cut -d'.' -f 1)
-   mapfile -t non_eurolinux_rpms < <(rpm -qa --qf "%{NEVRA}|%{VENDOR}|%{PACKAGER}\n" ${non_eurolinux_rpms_from_yum_list[*]} | grep -Ev 'EuroLinux|Scientific') 
-  if [[ -n "${non_eurolinux_rpms[*]}" ]]; then
+   mapfile -t non_eurolinux_rpms_and_metadata < <(rpm -qa --qf "%{NEVRA}|%{VENDOR}|%{PACKAGER}\n" ${non_eurolinux_rpms_from_yum_list[*]} | grep -Ev 'EuroLinux|Scientific') 
+  if [[ -n "${non_eurolinux_rpms_and_metadata[*]}" ]]; then
     echo "The following non-EuroLinux RPMs are installed on the system:"
-    printf '\t%s\n' "${non_eurolinux_rpms[@]}"
+    printf '\t%s\n' "${non_eurolinux_rpms_and_metadata[@]}"
     echo "This may be expected of your environment and does not necessarily indicate a problem."
     echo "If a large number of RPMs from other vendors are included and you're unsure why please open an issue on ${github_url}"
     if [ "$preserve" != "true" ]; then
-      echo "Removing these packages automatically..."
-      yum remove-nevra -y "${non_eurolinux_rpms[@]%%|*}"
+      echo "Removing these packages (except those kernel-related) automatically..."
+      non_eurolinux_rpms=( ${non_eurolinux_rpms_and_metadata[@]%%|*} )
+      yum remove-nevra -y ${non_eurolinux_rpms[@]/kernel*/}
     fi
-
   fi
 }
 

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -494,8 +494,10 @@ remove_centos_yum_branding() {
   # CentOS provides their branding in /etc/yum.conf. As of 2021.09.03 no other
   # distro appears to do the same but if this changes, equivalent branding
   # removals will be provided here.
-  echo "Removing CentOS-specific yum configuration from /etc/yum.conf if applicable..."
-  sed -i.bak -e 's/^distroverpkg/#&/g' -e 's/^bugtracker_url/#&/g' /etc/yum.conf
+  if [[ "$old_release" =~ centos ]]; then
+    echo "Removing CentOS-specific yum configuration from /etc/yum.conf..."
+    sed -i.bak -e 's/^distroverpkg/#&/g' -e 's/^bugtracker_url/#&/g' /etc/yum.conf
+  fi
 }
 
 fix_oracle_shenanigans() {

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -540,7 +540,6 @@ force_el_release() {
           yum download el-release
           dep_check yumdownloader
           ;;
-        *) : ;;
     esac
     for i in ${bad_packages[@]} ; do rpm -e --nodeps $i || true ; done
 

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -519,7 +519,6 @@ fix_oracle_shenanigans() {
         ;;
       7*)
         yum remove -y uname26
-        yum downgrade -y qemu-guest-agent
         ;;
       esac
   fi

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -664,7 +664,7 @@ reinstall_all_rpms() {
   # Since earlier EuroLinux packages are branded as Scientific Linux, an
   # additional pattern is considered when looking up EuroLinux products.
   # Some packages may not be branded properly - we use `yum` to determine
-  # their origin and then chech with `rpm`.
+  # their origin and then check with `rpm`.
   # When listing packages with `yum`, there may be a few which are listed with
   # two lines rather than one due to their long filename - the output is
   # modified via `sed` to deal with this curiosity.

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -14,7 +14,7 @@ beginning_preparations() {
   # These are all the packages we need to remove. Some may not reside in
   # this array since they'll be swapped later on once EuroLinux
   # repositories have been added.
-  bad_packages=(almalinux-backgrounds almalinux-backgrounds-extras almalinux-indexhtml almalinux-logos almalinux-release almalinux-release-opennebula-addons bcache-tools btrfs-progs centos-backgrounds centos-gpg-keys centos-indexhtml centos-linux-release centos-linux-repos centos-logos centos-release centos-release-advanced-virtualization centos-release-ansible26 centos-release-ansible-27 centos-release-ansible-28 centos-release-ansible-29 centos-release-azure centos-release-ceph-jewel centos-release-ceph-luminous centos-release-ceph-nautilus centos-release-ceph-octopus centos-release-configmanagement centos-release-cr centos-release-dotnet centos-release-fdio centos-release-gluster40 centos-release-gluster41 centos-release-gluster5 centos-release-gluster6 centos-release-gluster7 centos-release-gluster8 centos-release-gluster-legacy centos-release-messaging centos-release-nfs-ganesha28 centos-release-nfs-ganesha30 centos-release-nfv-common centos-release-nfv-openvswitch centos-release-openshift-origin centos-release-openstack-queens centos-release-openstack-rocky centos-release-openstack-stein centos-release-openstack-train centos-release-openstack-ussuri centos-release-opstools centos-release-ovirt42 centos-release-ovirt43 centos-release-ovirt44 centos-release-paas-common centos-release-qemu-ev centos-release-qpid-proton centos-release-rabbitmq-38 centos-release-samba411 centos-release-samba412 centos-release-scl centos-release-scl-rh centos-release-storage-common centos-release-virt-common centos-release-xen centos-release-xen-410 centos-release-xen-412 centos-release-xen-46 centos-release-xen-48 centos-release-xen-common desktop-backgrounds-basic insights-client libreport-centos libreport-plugin-mantisbt libreport-plugin-rhtsupport libreport-rhel libreport-rhel-anaconda-bugzilla libreport-rhel-bugzilla oracle-backgrounds oracle-epel-release-el8 oracle-indexhtml oraclelinux-release oraclelinux-release-el7 oraclelinux-release-el8 oracle-logos python3-dnf-plugin-ulninfo python3-syspurpose python-oauth redhat-backgrounds Red_Hat_Enterprise_Linux-Release_Notes-7-en-US redhat-indexhtml redhat-logos redhat-release redhat-release-eula redhat-release-server redhat-support-lib-python redhat-support-tool rocky-backgrounds rocky-gpg-keys rocky-indexhtml rocky-logos rocky-obsolete-packages rocky-release rocky-repos sl-logos uname26 yum-conf-extras yum-conf-repos)
+  bad_packages=(almalinux-backgrounds almalinux-backgrounds-extras almalinux-indexhtml almalinux-logos almalinux-release almalinux-release-opennebula-addons bcache-tools btrfs-progs centos-backgrounds centos-gpg-keys centos-indexhtml centos-linux-release centos-linux-repos centos-logos centos-release centos-release-advanced-virtualization centos-release-ansible26 centos-release-ansible-27 centos-release-ansible-28 centos-release-ansible-29 centos-release-azure centos-release-ceph-jewel centos-release-ceph-luminous centos-release-ceph-nautilus centos-release-ceph-octopus centos-release-configmanagement centos-release-cr centos-release-dotnet centos-release-fdio centos-release-gluster40 centos-release-gluster41 centos-release-gluster5 centos-release-gluster6 centos-release-gluster7 centos-release-gluster8 centos-release-gluster-legacy centos-release-messaging centos-release-nfs-ganesha28 centos-release-nfs-ganesha30 centos-release-nfv-common centos-release-nfv-openvswitch centos-release-openshift-origin centos-release-openstack-queens centos-release-openstack-rocky centos-release-openstack-stein centos-release-openstack-train centos-release-openstack-ussuri centos-release-opstools centos-release-ovirt42 centos-release-ovirt43 centos-release-ovirt44 centos-release-paas-common centos-release-qemu-ev centos-release-qpid-proton centos-release-rabbitmq-38 centos-release-samba411 centos-release-samba412 centos-release-scl centos-release-scl-rh centos-release-storage-common centos-release-virt-common centos-release-xen centos-release-xen-410 centos-release-xen-412 centos-release-xen-46 centos-release-xen-48 centos-release-xen-common centos-repos desktop-backgrounds-basic insights-client libreport-centos libreport-plugin-mantisbt libreport-plugin-rhtsupport libreport-rhel libreport-rhel-anaconda-bugzilla libreport-rhel-bugzilla oracle-backgrounds oracle-epel-release-el8 oracle-indexhtml oraclelinux-release oraclelinux-release-el7 oraclelinux-release-el8 oracle-logos python3-dnf-plugin-ulninfo python3-syspurpose python-oauth redhat-backgrounds Red_Hat_Enterprise_Linux-Release_Notes-7-en-US redhat-indexhtml redhat-logos redhat-release redhat-release-eula redhat-release-server redhat-support-lib-python redhat-support-tool rocky-backgrounds rocky-gpg-keys rocky-indexhtml rocky-logos rocky-obsolete-packages rocky-release rocky-repos sl-logos uname26 yum-conf-extras yum-conf-repos)
 }
 
 usage() {
@@ -424,80 +424,10 @@ print(my_org)
 }
 
 disable_distro_repos() {
-  # Remove all non-Eurolinux .repo files unless the 'preserve' option has been
-  # provided. If it was, then here's a summary of the function's logic:
-  # Different distros provide their repositories in different ways. There may
-  # be some additional .repo files that are covered by distro X but not by
-  # distro Y. The files may be provided by different packages rather than a
-  # <distro>-release RPM. This function will take care of all these
-  # inconsistencies to disable all the distro-specific repositories.
-  # This is the case mentioned in check_supported_releases() comments about
-  # overriding the old_release variable because of different .repo files'
-  # provider for certain distros.
-  # The procedure may be simplified but not replaced by using a '*.repo' glob 
-  # since there may be some third-party repositories that should not be
-  # disabled such as EPEL - only take care of another Enterprise Linux
-  # repositories.
-
+  # Remove all non-Eurolinux .repo files
   cd "$reposdir"
-
-  if [ "$preserve" != "true" ]; then
-    rm -f *.repo
-    create_temp_el_repo
-  else
-    cd "$(mktemp -d)"
-    trap final_failure ERR
-
-    # Most distros keep their /etc/yum.repos.d content in the -release rpm. Some do not and here are the tweaks for their more complex solutions...
-    case "$old_release" in
-      centos-release-8.*|centos-linux-release-8.*)
-        old_release=$(rpm -qa centos*repos) ;;
-      rocky-release*)
-        old_release=$(rpm -qa rocky*repos) ;;
-      oraclelinux-release-8.*)
-        old_release=$(rpm -qa oraclelinux-release-el8*) ;;
-      oraclelinux-release-7.*)
-        old_release=$(rpm -qa oraclelinux-release-el7*) ;;
-      *) : ;;
-    esac
-
-    echo "Backing up and removing old repository files..."
-
-    # ... this one should apply to any Enterprise Linux except RHEL:
-    echo "Identify repo files from the base OS..."
-    if [[ "$old_release" =~ redhat-release ]]; then
-      echo "RHEL detected and repo files are not provided by 'release' package."
-    else
-      rpm -ql "$old_release" | grep '\.repo$' > repo_files
-    fi
-
-    # ... and the complex solutions continue with these checks:
-    if [ "$(rpm -qa "centos-release*" | wc -l)" -gt 0 ] ; then
-    echo "Identify repo files from 'CentOS extras'..."
-      rpm -qla "centos-release*" | grep '\.repo$' >> repo_files
-    fi
-
-    if [ "$(rpm -qa "yum-conf-*" | wc -l)" -gt 0 ] ; then
-    echo "Identify repo files from 'Scientific Linux extras'..."
-      rpm -qla "yum-conf-*" | grep '\.repo$' >> repo_files
-    fi
-
-    # ... finally we should have all the old repos disabled!
-    while read -r repo; do
-      if [ -f "$repo" ]; then
-        cat - "$repo" > "$repo".disabled <<EOF
-# This is a yum repository file that was disabled by
-# ${0##*/}, a script to convert an Enterprise Linux variant to EuroLinux.
-# Please see $github_url for more information.
-
-EOF
-        tmpfile=$(mktemp repo.XXXXX)
-        echo "$repo" | cat - "$repo" > "$tmpfile"
-        rm "$repo"
-      fi
-    done < repo_files
-    trap - ERR
-  fi
+  rm -f *.repo
+  create_temp_el_repo
 }
 
 remove_centos_yum_branding() {


### PR DESCRIPTION
Hotfix for CentOS 8.2 - remove an additional bad package and don't preserve old .repo files. The preservation logic is present in another branch and will be brought back once further testing has been done for several minor releases compatibility.