### PR TITLE
Fixes related to several edge case issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ The following distributions are supported on the x86_64 architecture:
 - Rocky Linux 8.4
 - Scientific Linux 7.9
 
-If a system has been installed with Secure Boot enabled, make sure that it is
-disabled first before running the script.
+It is possible to migrate from other release versions such as 8.2 or 8.5 since
+the script should succeed in syncing the packages to EuroLinux 8.4 equivalents
+but it's not officially supported. Analogically a migration from 7.4 upwards
+should succeed in syncing to EuroLinux 7.9.  
+**If a system has been installed with Secure Boot enabled, make sure that it
+is disabled first before running the script.**
 
 ## Preparations
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,7 @@ production machines.
 If libvirt is used as Vagrant provider, simply uncomment the following
 snippet and adjust the ISO image path:
 ```ruby
-  #config.vm.provider "libvirt" do |libvirt|
   #  libvirt.storage :file, :device => :cdrom, :path => "/var/lib/libvirt/images/mirror.iso"
-  #end
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -9,20 +9,18 @@ equivalents.
 ## Support
 
 The following distributions are supported on the x86_64 architecture:
-- AlmaLinux 8
-- CentOS 7
-- CentOS 8
-- Oracle Linux 7
-- Oracle Linux 8
-- Red Hat Enterprise Linux 7
-- Red Hat Enterprise Linux 8
-- Rocky Linux 8
-- Scientific Linux 7
+- AlmaLinux 8.4
+- CentOS 7.9
+- CentOS 8.4
+- Oracle Linux 7.9
+- Oracle Linux 8.4
+- Red Hat Enterprise Linux 7.9
+- Red Hat Enterprise Linux 8.4
+- Rocky Linux 8.4
+- Scientific Linux 7.9
 
-The distributions must be up to date and only their latest minor release is
-supported.  
-Additionally, if a system has been installed with Secure Boot enabled,
-make sure that it is disabled first before running the script.
+If a system has been installed with Secure Boot enabled, make sure that it is
+disabled first before running the script.
 
 ## Preparations
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ that all assets such as keys and certificates related to that management
 service have been backed up if necessary and that the system has been
 unregistered before running the script. The script will attempt to detect a
 valid subscription and inform you on the steps required before proceeding if
-one is found.
+one is found.  
+Make sure that your system does not use any centralized package management
+suite. The script will provide EuroLinux repositories but as of today it has
+no knowledge of the suite mentioned - package collisions are likely to happen.
+Please disable the suite if necessary before attempting to migrate.  
+Check your system if there's a file mounted directly at the directory `/mnt`
+or if the directory `/sys` is mounted as read-only. Make sure none of this
+applies, otherwise the migration will not succeed. An example of an error is
+presented later on.
 
 ## Usage
 
@@ -168,6 +176,6 @@ Failed:
 Error: Transaction failed
 ```
 
-Most likely you performed an offline migration with an ISO image mounted
-directly at */mnt*. Make sure that only its subdirectories are used as mount
-points.
+Most likely you performed an offline migration with an ISO image (or a
+different file) mounted directly at */mnt*. Make sure that only its
+subdirectories are used as mount points.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The following distributions are supported on the x86_64 architecture:
 - Scientific Linux 7
 
 It is possible to migrate from other release versions such as 8.2 since the
-script should succeed in syncing the packages to newest EuroLinux equivalents
-but it's not officially supported. Analogically a migration from 7.4 upwards
-should succeed in syncing to EuroLinux 7.9.  
+script should succeed in syncing the packages to EuroLinux equivalents but it's
+not officially supported. Analogically a migration from 7.4 upwards should
+succeed in syncing to EuroLinux 7.9.  
 **If a system has been installed with Secure Boot enabled, make sure that it
 is disabled first before running the script.**
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ equivalents.
 ## Support
 
 The following distributions are supported on the x86_64 architecture:
-- AlmaLinux 8.4
-- CentOS 7.9
-- CentOS 8.4
-- Oracle Linux 7.9
-- Oracle Linux 8.4
-- Red Hat Enterprise Linux 7.9
-- Red Hat Enterprise Linux 8.4
-- Rocky Linux 8.4
-- Scientific Linux 7.9
+- AlmaLinux 8
+- CentOS 7
+- CentOS 8
+- Oracle Linux 7
+- Oracle Linux 8
+- Red Hat Enterprise Linux 7
+- Red Hat Enterprise Linux 8
+- Rocky Linux 8
+- Scientific Linux 7
 
-It is possible to migrate from other release versions such as 8.2 or 8.5 since
-the script should succeed in syncing the packages to EuroLinux 8.4 equivalents
+It is possible to migrate from other release versions such as 8.2 since the
+script should succeed in syncing the packages to newest EuroLinux equivalents
 but it's not officially supported. Analogically a migration from 7.4 upwards
 should succeed in syncing to EuroLinux 7.9.  
 **If a system has been installed with Secure Boot enabled, make sure that it

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,10 @@
 Vagrant.configure("2") do |config|
   config.vm.box_check_update = false
   config.vm.synced_folder '.', '/vagrant', type: "rsync"
-  #config.vm.provider "libvirt" do |libvirt|
+  config.vm.provider "libvirt" do |libvirt|
+    libvirt.random_hostname = true
   #  libvirt.storage :file, :device => :cdrom, :path => "/var/lib/libvirt/images/mirror.iso"
-  #end
+  end
 
   config.vm.define "almalinux8" do |i|
     i.vm.box = "eurolinux-vagrant/almalinux-8"

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -681,6 +681,15 @@ reinstalled_rpms_fixes() {
   rpm -qa 'ipa-server' | grep module && ipa-server-upgrade --skip-version-check
 }
 
+reinstall_all_rpms() {
+  # A safety measure - all packages will be reinstalled and later on compared
+  # if they belong to EuroLinux or not. If not, this might not be a problem at
+  # all - it depends if they are from other vendors you migrated from or third
+  # party repositories such as EPEL.
+  echo "Reinstalling all RPMs..."
+  yum reinstall -y \*
+}
+
 compare_all_rpms() {
   # Once an internal .repo file is provided, search for the names of the
   # offline repositories and construct them as a grep pattern. Take a look

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -672,15 +672,6 @@ deal_with_problematic_rpms() {
   esac
 }
 
-reinstalled_rpms_fixes() {
-  # Reinstalling OpenJDK packages breaks their links in /etc/alternatives:
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1976053
-  rpm -qa --scripts java-*-openjdk-* | sed -n '/postinstall/, /exit/{ /postinstall/! { /exit/ ! p} }' | sh
-
-  # ipa fix
-  rpm -qa 'ipa-server' | grep module && ipa-server-upgrade --skip-version-check
-}
-
 reinstall_all_rpms() {
   # A safety measure - all packages will be reinstalled and later on compared
   # if they belong to EuroLinux or not. If not, this might not be a problem at
@@ -688,6 +679,15 @@ reinstall_all_rpms() {
   # party repositories such as EPEL.
   echo "Reinstalling all RPMs..."
   yum reinstall -y \*
+}
+
+fix_reinstalled_rpms() {
+  # Reinstalling OpenJDK packages breaks their links in /etc/alternatives:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1976053
+  rpm -qa --scripts java-*-openjdk-* | sed -n '/postinstall/, /exit/{ /postinstall/! { /exit/ ! p} }' | sh
+
+  # ipa fix
+  rpm -qa 'ipa-server' | grep module && ipa-server-upgrade --skip-version-check
 }
 
 compare_all_rpms() {
@@ -806,7 +806,8 @@ main() {
   el_distro_sync
   restore_modules
   deal_with_problematic_rpms
-  reinstalled_rpms_fixes
+  reinstall_all_rpms
+  fix_reinstalled_rpms
   compare_all_rpms
   update_grub
   remove_leftovers

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -216,7 +216,7 @@ check_systemwide_python() {
 
 reset_modules() {
   mapfile -t modules_enabled < <(sudo dnf module list --enabled | grep -E '^[^:.]+\ +.+\[e\]' | cut -d ' ' -f 1)
-  dnf module reset -y ${modules_enabled[*]}
+  dnf module disable -y ${modules_enabled[*]}
 }
 
 get_branded_modules() {
@@ -700,7 +700,7 @@ debrand_modules() {
 }
 
 restore_modules() {
-  dnf module enable -y ${modules_enabled[*]}
+  dnf module enable -y ${modules_enabled[*]} || dnf module install -y ${modules_enabled[*]}
 }
 
 deal_with_problematic_rpms() {
@@ -740,6 +740,9 @@ reinstall_all_rpms() {
   # Reinstalling OpenJDK packages breaks their links in /etc/alternatives:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1976053
   rpm -qa --scripts java-*-openjdk-* | sed -n '/postinstall/, /exit/{ /postinstall/! { /exit/ ! p} }' | sh
+
+  # ipa fix
+  rpm -qa 'ipa-server' | grep module && ipa-server-upgrade --skip-version-check
 }
 
 compare_all_rpms() {

--- a/migrate2eurolinux.sh
+++ b/migrate2eurolinux.sh
@@ -728,6 +728,12 @@ reinstall_all_rpms() {
   echo "Reinstalling all RPMs..."
   yum reinstall -y \*
 
+  # Reinstalling OpenJDK packages breaks their links in /etc/alternatives:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1976053
+  rpm -qa --scripts java-*-openjdk-* | sed -n '/postinstall/, /exit/{ /postinstall/! { /exit/ ! p} }' | sh
+}
+
+compare_all_rpms() {
   # Once an internal .repo file is provided, search for the names of the
   # offline repositories and construct them as a grep pattern. Take a look
   # at the pipe symbol: | before a command substitution takes place - it
@@ -845,6 +851,7 @@ main() {
   debrand_modules
   deal_with_problematic_rpms
   reinstall_all_rpms
+  compare_all_rpms
   update_grub
   remove_leftovers
   verify_generated_rpms_info


### PR DESCRIPTION
- Implemented restoration of a link in alternatives related to OpenJDK after it's reinstalled
- Better module handling and simplified Oracle Linux module rebranding
- Fixed migration failure with the module `@idm:DL1` installed.
- Mentioned several precautions in README.
- Vagrant machine names should be unique from now on no matter what directory they're brought up from.