### PR TITLE
Changes related to file provisioning and paths inside boxes for tests

### DIFF
--- a/tests/run_migration_test.sh
+++ b/tests/run_migration_test.sh
@@ -6,7 +6,7 @@
 # (the whole project's directory by default). With automated tests you'll most
 # likely want to `vagrant up box`, ensuring that this script landed in a box,
 # first and run this script with a wrapper executed on a **Vagrant host** like:
-# `vagrant ssh box -c "cd /vagrant/tests && \
+# `vagrant ssh box -c "cd /home/vagrant/eurolinux-migration-scripts/tests && \
 #   ./run_migration_test.sh test1 test2 test3" | tee -a my_tests_logs.log`
 #
 # Copyright 2021 EuroLinux, Inc.
@@ -34,7 +34,8 @@ eval "$(grep -E "\#\ $HOSTNAME" skipped_tests.txt)"
 echo "Tests that will be skipped for $HOSTNAME: ${tests_to_skip[*]}"
 
 # Run the tests!
-cd "/vagrant/tests/EL-core-functional-tests/" || exit
+cd "/home/vagrant/eurolinux-migration-scripts/\
+tests/EL-core-functional-tests/" || exit
 
 for test in "${tests[@]}" ; do
   if [[ "${tests_to_skip[*]}" =~ ${test} ]]; then

--- a/tests/wrapper.sh
+++ b/tests/wrapper.sh
@@ -61,12 +61,12 @@ done
 
 # Perform tests per each box
 for box in ${boxes[*]}; do
-  vagrant rsync "$box"
   # Run the tests by executing the already-rsynced run_migration_test.sh
   # script that will take care of the actual execution of the tests with
   # everything happening in a box and skipping problematic tests per distro.
   vagrant ssh "$box" -c \
-    "cd /vagrant/tests && ./run_migration_test.sh ${tests[*]}" \
+    "cd /home/vagrant/eurolinux-migration-scripts/tests && \
+      ./run_migration_test.sh ${tests[*]}" \
       | tee -a "${box}_migration_tests.log"
 done
 


### PR DESCRIPTION
Ever since I implemented file provisioning as a replacement for rsync, which is not available in the `general-rhelX` boxes, I changed the paths of the synced files so they resemble how one might clone this repository directly in a virtual machine. The scripts that run our tests shall also reflect the new paths.